### PR TITLE
refactor: pipeline should publish docker image when branch is `develop`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ jobs:
     executor: docker/machine
     steps:
       - checkout
-      - docker/check
       - docker/build:
           image: boilerplate
           tag: latest
@@ -44,7 +43,6 @@ workflows:
       - image:
           requires:
             - client
-          registry: $CONTAINER_REGISTRY
       - docker/publish:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,16 +25,28 @@ jobs:
       - run:
           command: yarn run build
           name: Build Boilerplate
-  image:
+  image-build:
     executor: docker/machine
     steps:
       - checkout
       - docker/check:
           registry: $CONTAINER_REGISTRY
       - docker/build:
+          registry: $CONTAINER_REGISTRY
           image: boilerplate
           tag: latest
           extra_build_args: "--secret id=DHAMPIR_NPM_ACCESS_TOKEN --build-arg DHAMPIR_NPM_REGISTRY=$DHAMPIR_NPM_REGISTRY"
+
+  image-publish:
+    executor: docker/machine
+    steps:
+      - checkout
+      - docker/publish:
+          registry: $CONTAINER_REGISTRY
+          image: boilerplate
+          tag: latest
+          extra_build_args: "--secret id=DHAMPIR_NPM_ACCESS_TOKEN --build-arg DHAMPIR_NPM_REGISTRY=$DHAMPIR_NPM_REGISTRY"
+
 
 
 # Invoke jobs via workflows
@@ -43,18 +55,15 @@ workflows:
   build:
     jobs:
       - client
-      - image:
+      - image-build:
           requires:
             - client
-      - docker/publish:
+      - image-publish:
           filters:
             branches:
               only:
                 - develop
           requires:
             - client
-            - image
-          registry: $CONTAINER_REGISTRY
-          image: boilerplate
-          tag: latest
-          extra_build_args: "--secret id=DHAMPIR_NPM_ACCESS_TOKEN --build-arg DHAMPIR_NPM_REGISTRY=$DHAMPIR_NPM_REGISTRY"
+            - image-build
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
   client:
     executor:
       name: node/default
-      tag: '20'
+      tag: '20.17.0'
     steps:
       - checkout
       - node/install-packages:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ workflows:
       - image:
           requires:
             - client
+          extra_build_args: "--secret id=DHAMPIR_NPM_ACCESS_TOKEN --build-arg DHAMPIR_NPM_REGISTRY=$DHAMPIR_NPM_REGISTRY"
       - docker/publish:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,12 @@ jobs:
     executor: docker/machine
     steps:
       - checkout
+      - docker/check:
+          registry: $CONTAINER_REGISTRY
       - docker/build:
           image: boilerplate
           tag: latest
+          extra_build_args: "--secret id=DHAMPIR_NPM_ACCESS_TOKEN --build-arg DHAMPIR_NPM_REGISTRY=$DHAMPIR_NPM_REGISTRY"
 
 
 # Invoke jobs via workflows
@@ -43,7 +46,6 @@ workflows:
       - image:
           requires:
             - client
-          extra_build_args: "--secret id=DHAMPIR_NPM_ACCESS_TOKEN --build-arg DHAMPIR_NPM_REGISTRY=$DHAMPIR_NPM_REGISTRY"
       - docker/publish:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,22 +10,30 @@ orbs:
 # See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
   client:
-    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
-    docker:
-      - image: cimg/base:stable
-    # Add steps to the job
-    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+    executor:
+      name: node/default
+      tag: '20'
     steps:
       - checkout
-      - node/install:
-          install-yarn: true
-          node-version: "20.17"
-      - run: npm i -g corepack
-      - run: corepack enable
-      - run: yarn set version berry
-      - run: yarn install --frozen-lockfile
-      - run: yarn run build
+      - node/install-packages:
+          check-cache: always
+          pkg-manager: yarn-berry
+          with-cache: false
+      - run:
+          command: yarn install --immutable
+          name: Install Dependencies
+      - run:
+          command: yarn run build
+          name: Build Boilerplate
+  image:
+    executor: docker/machine
+    steps:
+      - checkout
+      - docker/check
+      - docker/build:
+          image: boilerplate
+          tag: latest
+
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
@@ -33,9 +41,15 @@ workflows:
   build:
     jobs:
       - client
-  publish-docker-image:
-    jobs:
+      - image
       - docker/publish:
+          filters:
+            branches:
+              only:
+                - develop
+          requires:
+            - client
+            - image
           registry: $CONTAINER_REGISTRY
           image: boilerplate
           tag: latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,11 +41,15 @@ jobs:
     executor: docker/machine
     steps:
       - checkout
-      - docker/publish:
+      - docker/build:
           registry: $CONTAINER_REGISTRY
           image: boilerplate
           tag: latest
           extra_build_args: "--secret id=DHAMPIR_NPM_ACCESS_TOKEN --build-arg DHAMPIR_NPM_REGISTRY=$DHAMPIR_NPM_REGISTRY"
+      - docker/push:
+          registry: $CONTAINER_REGISTRY
+          image: boilerplate
+          tag: latest
 
 
 

--- a/.circleci/pr.yml
+++ b/.circleci/pr.yml
@@ -12,7 +12,7 @@ jobs:
   client:
     executor:
       name: node/default
-      tag: '20.17.0'
+      tag: '20'
     steps:
       - checkout
       - node/install-packages:
@@ -28,32 +28,17 @@ jobs:
   image:
     executor: docker/machine
     steps:
-      - checkout
-      - docker/check
-      - docker/build:
-          image: boilerplate
-          tag: latest
+        - checkout
+        - docker/check
+        - docker/build:
+            image: boilerplate
+            tag: latest
 
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
 workflows:
-  build:
+  pull-request:
     jobs:
       - client
-      - image:
-          requires:
-            - client
-          registry: $CONTAINER_REGISTRY
-      - docker/publish:
-          filters:
-            branches:
-              only:
-                - develop
-          requires:
-            - client
-            - image
-          registry: $CONTAINER_REGISTRY
-          image: boilerplate
-          tag: latest
-          extra_build_args: "--secret id=DHAMPIR_NPM_ACCESS_TOKEN --build-arg DHAMPIR_NPM_REGISTRY=$DHAMPIR_NPM_REGISTRY"
+      - image


### PR DESCRIPTION
This PR adds:

1. filter for `docker/publish` job to be run only in `develop`
2. job that checks `Dockerfile` and builds image